### PR TITLE
fix: change ids to specs rather than drafts.opds.io

### DIFF
--- a/schema/acquisition-object.schema.json
+++ b/schema/acquisition-object.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://drafts.opds.io/schema/acquisition-object.schema.json",
+  "$id": "https://specs.opds.io/schema/acquisition-object.schema.json",
   "title": "OPDS Acquisition Object",
   "type": "object",
   "properties": {

--- a/schema/feed-metadata.schema.json
+++ b/schema/feed-metadata.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://drafts.opds.io/schema/feed-metadata.schema.json",
+  "$id": "https://specs.opds.io/schema/feed-metadata.schema.json",
   "title": "OPDS Metadata",
   "type": "object",
   "properties": {

--- a/schema/feed.schema.json
+++ b/schema/feed.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://drafts.opds.io/schema/feed.schema.json",
+  "$id": "https://specs.opds.io/schema/feed.schema.json",
   "title": "OPDS Feed",
   "type": "object",
   "properties": {

--- a/schema/properties.schema.json
+++ b/schema/properties.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://drafts.opds.io/schema/properties.schema.json",
+  "$id": "https://specs.opds.io/schema/properties.schema.json",
   "title": "OPDS Link Properties",
   "type": "object",
   "properties": {

--- a/schema/publication.schema.json
+++ b/schema/publication.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://drafts.opds.io/schema/publication.schema.json",
+  "$id": "https://specs.opds.io/schema/publication.schema.json",
   "title": "OPDS Publication",
   "type": "object",
   "properties": {


### PR DESCRIPTION
Currently all OPDS 2.0 schemas still had `https://drafts.opds.io/`.

Not only did those not resolve anymore, this also lead to invalid JSON schema references, as eg the [Readium WebPub Link schema](https://readium.org/webpub-manifest/schema/link.schema.json) did already point to `https://specs.opds.io`.


This just renames all `drafts.opds.io` links to `specs.opds.io` links.

Note: There are still quite some references to the drafts.opds.io in eg the kotlin, swift, and ts-toolkits, eg

https://github.com/readium/kotlin-toolkit//blob/e41d6d8a352716319c199c70f878f53544410663/readium/shared/src/main/java/org/readium/r2/shared/opds/Availability.kt#L28-L35

I'm happy to also open PRs there to change those references, although they are less impactful.


