### PR TITLE
fix: add download acquisition relation

### DIFF
--- a/schema/publication.schema.json
+++ b/schema/publication.schema.json
@@ -70,6 +70,7 @@
         "acquisition",
         "borrow",
         "buy",
+        "download",
         "preview",
         "subscribe",
         "http://opds-spec.org/acquisition",


### PR DESCRIPTION
[Section 5.3](https://specs.opds.io/opds-2.0.html#53-acquisition-links) indicates that `download` is a valid rel, but it is missing in the publication schema acquisition rel enum.

